### PR TITLE
Added auto-installation script

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Tested with Inkscape v 1.4.2 on Fedora Linux 42 with Gnome 48.
 
 ##### Installation with a script
 
-1. Install or update adw-gimp3 via the command below:
+1. Install or update <b>adw-inkscape</b> via the command below:
 
     ```bash
     curl -s https://raw.githubusercontent.com/RichardSepsi/adw-inkscape/main/install.sh | bash

--- a/README.md
+++ b/README.md
@@ -22,10 +22,10 @@ Tested with Inkscape v 1.4.2 on Fedora Linux 42 with Gnome 48.
 
 ##### Manual installation
 1. Download the repo and extract the files
-2. Put style.css to `/usr/share/inkscape/ui` (! This will replace the original style.css that came with inkscape so make sure to back up before replacing !)
+2. Put style.css to `~/.config/inkscape/ui/` (! This will replace the original style.css that came with inkscape so make sure to back up before replacing !)
 3. Put `adw-inkscape` to your user themes directory:
-- for native packages: `~/.local/share/themes`
-- for flatpak: `~/.var/app/org.inkscape/Inkscape/data/themes`
+- for native packages: `~/.local/share/themes/`
+- for flatpak: `~/.var/app/org.inkscape/Inkscape/data/themes/`
 4. Launch Inkscape
 5. Navigate to `Edit → Preferences → Interface → Theming`
 6. Change the GTK theme to `adw-inkscape` (or `adw-inkscape-left-controls` for left-side window titlebar icons)

--- a/README.md
+++ b/README.md
@@ -8,7 +8,24 @@ Tested with Inkscape v 1.4.2 on Fedora Linux 42 with Gnome 48.
 <img width="2022" height="1129" alt="light" src="https://github.com/user-attachments/assets/60f6d9b6-95aa-441c-85f9-1ea311f4a382" />
 
 ## Installation
+
+##### Installation with a script
+
+1. Install or update adw-gimp3 via the command below:
+
+    ```bash
+    curl -s https://raw.githubusercontent.com/RichardSepsi/adw-inkscape/main/install.sh | bash
+    ```
+2. Launch Inkscape
+3. Navigate to `Edit → Preferences → Interface → Theming`
+4. Change the GTK theme to `adw-inkscape` (or `adw-inkscape-left-controls` for left-side window titlebar icons)
+
+##### Manual installation
 1. Download the repo and extract the files
-2. Put style.css to "/usr/share/inkscape/ui" (! This will replace the original style.css that came with inkscape so make sure to back up before replacing !)
-3. Put adw-inkscape to your user themes directory. If you put window titlebar buttons on the left side, you have to use the adw-inkscape-left controls folder instead! (You can find the themes directory under edit > preferences > interface > theming > "User themes:").
-5. Start inkscape and change the theme in the preferences (edit > preferences > interface > theming > Change GTK theme: adw-inkscape)
+2. Put style.css to `/usr/share/inkscape/ui` (! This will replace the original style.css that came with inkscape so make sure to back up before replacing !)
+3. Put `adw-inkscape` to your user themes directory:
+- for native packages: `~/.local/share/themes`
+- for flatpak: `~/.var/app/org.inkscape/Inkscape/data/themes`
+4. Launch Inkscape
+5. Navigate to `Edit → Preferences → Interface → Theming`
+6. Change the GTK theme to `adw-inkscape` (or `adw-inkscape-left-controls` for left-side window titlebar icons)

--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
-# adw-inkscape
-Inkscape adwaita theme.
+# adw-inkscape: an Adwaita theme for Inkscape
 Based on adw-gtk3: https://github.com/lassekongo83/adw-gtk3
 
-Tested with Inkscape v 1.4.2 on Fedora Linux 42 with Gnome 48. 
+Tested with Inkscape v1.4.2 on Fedora Linux 42 with Gnome 48. 
 
 <img width="2022" height="1129" alt="dark" src="https://github.com/user-attachments/assets/d10136b8-c75a-4559-b0c1-e0cfb781bbcf" />
 <img width="2022" height="1129" alt="light" src="https://github.com/user-attachments/assets/60f6d9b6-95aa-441c-85f9-1ea311f4a382" />
@@ -16,16 +15,16 @@ Tested with Inkscape v 1.4.2 on Fedora Linux 42 with Gnome 48.
     ```bash
     curl -s https://raw.githubusercontent.com/RichardSepsi/adw-inkscape/main/install.sh | bash
     ```
-2. Launch Inkscape
-3. Navigate to `Edit → Preferences → Interface → Theming`
-4. Change the GTK theme to `adw-inkscape` (or `adw-inkscape-left-controls` for left-side window titlebar icons)
 
 ##### Manual installation
 1. Download the repo and extract the files
-2. Put style.css to `~/.config/inkscape/ui/` (! This will replace the original style.css that came with inkscape so make sure to back up before replacing !)
+2. Put `style.css` to `~/.config/inkscape/ui/`
 3. Put `adw-inkscape` to your user themes directory:
 - for native packages: `~/.local/share/themes/`
 - for flatpak: `~/.var/app/org.inkscape/Inkscape/data/themes/`
-4. Launch Inkscape
-5. Navigate to `Edit → Preferences → Interface → Theming`
-6. Change the GTK theme to `adw-inkscape` (or `adw-inkscape-left-controls` for left-side window titlebar icons)
+
+##### Setup
+
+1. Launch Inkscape
+2. Navigate to `Edit → Preferences → Interface → Theming`
+3. Change the GTK theme to `adw-inkscape` (or `adw-inkscape-left-controls` for left-side window titlebar icons)

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+set -e
+
+APP="adw-inkscape"
+REPO="https://github.com/RichardSepsi/adw-inkscape"
+CLONE_DIR="$PWD/$APP"
+
+NATIVE="$HOME/.config/inkscape"
+FLATPAK="$HOME/.var/app/org.inkscape.Inkscape"
+
+echo -e "Installing \033[1m${APP}\033[0m..."
+sleep 0.5
+
+git clone $REPO $CLONE_DIR
+
+if [ -d "$NATIVE" ]; then
+	echo "Installing to: $NATIVE"
+	cp -r $CLONE_DIR/$APP ~/.local/share/themes
+	cp -f $CLONE_DIR/style.css $NATIVE/ui/
+elif [ -d "$FLATPAK" ]; then
+	echo "Installing to: $FLATPAK"
+	cp -r $CLONE_DIR/$APP $FLATPAK/data/themes
+	cp -f $CLONE_DIR/style.css $FLATPAK/config/inkscape/ui/
+fi
+
+rm -rf "$CLONE_DIR"
+echo "Installation complete!"

--- a/install.sh
+++ b/install.sh
@@ -16,11 +16,11 @@ git clone $REPO $CLONE_DIR
 
 if [ -d "$NATIVE" ]; then
 	echo "Installing to: $NATIVE"
-	cp -r $CLONE_DIR/$APP ~/.local/share/themes
+	cp -r $CLONE_DIR/$APP* ~/.local/share/themes/
 	cp -f $CLONE_DIR/style.css $NATIVE/ui/
 elif [ -d "$FLATPAK" ]; then
 	echo "Installing to: $FLATPAK"
-	cp -r $CLONE_DIR/$APP $FLATPAK/data/themes
+	cp -r $CLONE_DIR/$APP* $FLATPAK/data/themes/
 	cp -f $CLONE_DIR/style.css $FLATPAK/config/inkscape/ui/
 fi
 


### PR DESCRIPTION
Hi again, I created and added an auto-installation shell script, similar to how I did for `adw-gimp3`.

Few things to note:
1. I changed `/usr/share/inkscape` path to `~/.config/inkscape/`, so `sudo` is not necessary.
2. Inkscape uses the default GTK theme folder path for Inkscape themes (instead of the unused one in the Inkscape parent folder), so I made sure to explain that in the README, as well as in the script.